### PR TITLE
fix a bug for long texts and missing ^

### DIFF
--- a/iec16022.c
+++ b/iec16022.c
@@ -507,6 +507,9 @@ int main(int argc, const char *argv[])
       errx(1, "Unknown output format %s\n", format);
       break;
    }
+   
+   free(encoding);
+   free(grid);
 
    return 0;
 }

--- a/iec16022ecc200.c
+++ b/iec16022ecc200.c
@@ -272,7 +272,7 @@ char ecc200encode(unsigned char *t, int tl, unsigned char *s, int sl, char *enco
             unsigned int out[6];
             int p = 0;
             const char *e = 0,
-                *s2 = "!\"#$%&'()*+,-./:;<=>?@[\\]_",
+                *s2 = "!\"#$%&'()*+,-./:;<=>?@[\\]^_",
                 *s3 = 0;
             if (newenc == 'c')
             {
@@ -921,9 +921,9 @@ unsigned char *iec16022ecc200_opts(iec16022ecc200_t o)
          for (x = 0; x < W; x += matrix->FW)
          {
             for (y = 0; y < H; y++)
-               grid[(matrix->FH - 1 - y + q) * (W + q + q) + q + x] = 1;
+                grid[(H - 1 - y + q) * (W + q + q) + q + x] = 1;
             for (y = 0; y < H; y += 2)
-               grid[(matrix->FH - 1 - y + q) * (W + q + q) + q + x + matrix->FW - 1] = 1;
+               grid[(H - 1 - y + q) * (W + q + q) + q + x + matrix->FW - 1] = 1;
          }
          for (y = 0; y < NR; y++)
          {


### PR DESCRIPTION
Fix two bugs:

1. bug 1: "_" as "^"
./datamatrix -q -c hello_world_ATGC --eps -o hello.eps

2. bug2: crash for long barcodes.
./dmcode -q -c "1175_GEN2B-pro-Berkut-FAM_GAAGGTTACCAAGTTCAAGCATTGTGAGGCCAGCACAGAGA"  --eps -o primer.eps